### PR TITLE
Separate Job_schedule block to allow multiple blocks and Validation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following resources are used by this module:
 - [azurerm_automation_credential.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_credential) (resource)
 - [azurerm_automation_hybrid_runbook_worker.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_hybrid_runbook_worker) (resource)
 - [azurerm_automation_hybrid_runbook_worker_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_hybrid_runbook_worker_group) (resource)
+- [azurerm_automation_job_schedule.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule) (resource)
 - [azurerm_automation_module.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_module) (resource)
 - [azurerm_automation_powershell72_module.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_powershell72_module) (resource)
 - [azurerm_automation_python3_package.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_python3_package) (resource)
@@ -250,7 +251,7 @@ Default: `{}`
 
 Description: A list of Automation Connections which should be created in this Automation Account.
   `name` - (Required) The name of the Connection.
-  `type` - (Required) The type of the Connection.
+  `type` - (Required) The type of the Connection. Can be either builtin type such as `Azure`, `AzureClassicCertificate`, and `AzureServicePrincipal`, or a user defined types. Changing this forces a new resource to be created.
   `values` - (Required) A mapping of key value pairs passed to the connection. Different `type` needs different parameters in the `values`. Builtin types have required field values as below:
     `Azure`: parameters `AutomationCertificateName` and `SubscriptionID`.
     `AzureServicePrincipal`: parameters `TenantID`, `ApplicationID`, and `CertificateThumbprint`.
@@ -424,6 +425,54 @@ map(object({
 
 Default: `{}`
 
+### <a name="input_automation_job_schedules"></a> [automation\_job\_schedules](#input\_automation\_job\_schedules)
+
+Description: A map of Automation Job Schedules to be created in this Automation Account.
+  `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
+  `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
+  `parameters` - (Optional) A map of parameters to pass to the Runbook.
+  `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
+  `timeouts` - (Optional) The timeouts block.
+
+Example Input:
+```terraform
+automation_job_schedule = {
+  "myjobschedule" = {
+    name          = "myjobschedule"
+    runbook_key  = "auto_runbook_key1"
+    schedule_key = "auto_schedule_key1"
+    parameters    = {
+      param1 = "value1"
+      param2 = "value2"
+    }
+    run_on = "Azure"
+    timeouts = {
+      create = "30m"
+      delete = "30m"
+      read   = "5m"
+    }
+  }
+}
+```
+
+Type:
+
+```hcl
+map(object({
+    runbook_key  = string
+    schedule_key = string
+    parameters   = optional(map(string)) # must be in lowercase
+    run_on       = optional(string)
+    timeouts = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      read   = optional(string)
+    }))
+  }))
+```
+
+Default: `{}`
+
 ### <a name="input_automation_modules"></a> [automation\_modules](#input\_automation\_modules)
 
 Description: A list of Automation Modules which should be created in this Automation Account.
@@ -543,7 +592,7 @@ Description: A list of Automation Python 3 packages which should be created in t
   `content_uri` - (Required) The URI of the content. Changing this forces a new Automation Python3 Package to be created.
   `content_version` - (Optional) The version of the content.  The value should meet the system.version class format like `1.1.1`. Changing this forces a new Automation Python3 Package to be created.
   `hash_algorithm` - (Optional) Specify the hash algorithm used to hash the content of the python3 package. Changing this forces a new Automation Python3 Package to be created.
-  `hash_value` - (Optional) Specity the hash value of the content. Changing this forces a new Automation Python3 Package to be created.
+  `hash_value` - (Optional) Specify the hash value of the content. Changing this forces a new Automation Python3 Package to be created.
   `tags` - (Optional) A mapping of tags to assign to the Module.
   `timeouts` - (Optional) The timeouts block.
 
@@ -595,13 +644,13 @@ Default: `{}`
 
 Description: A list of Automation Runbooks which should be created in this Automation Account.
   `name` - (Required) The name of the Runbook.
-  `runbook_type` - (Required) The type of the Runbook. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `GraphPython2`, `GraphPython3`, `GraphPowerShellCore`, `GraphPowerShellCoreWorkflow`, `GraphPowerShellCorePython2`, `GraphPowerShellCorePython3`, `GraphPowerShellCorePowerShell`, `GraphPowerShellCorePowerShellWorkflow`, `GraphPowerShellCorePowerShellPython2`, `GraphPowerShellCorePowerShellPython3`, `GraphPowerShellCorePowerShellCore`, `GraphPowerShellCorePowerShellCoreWorkflow`, `GraphPowerShellCorePowerShellCorePython2`, `GraphPowerShellCorePowerShellCorePython3`.
+  `runbook_type` - (Required) The type of the Runbook. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShell72`, `Python3`, `Python2` or `Script`.
   `log_process` - (Required) Whether to log process details. Defaults to `true`.
   `log_verbose` - (Required) Whether to log verbose details. Defaults to `true`.
   `description` - (Optional) A description for this Runbook.
   `content` - (Optional) The content of the Runbook. Required if `publish_content_link` is not specified.
   `tags` - (Optional) A mapping of tags to assign to the Runbook.
-  `log_activity_trace_level` - (Optional) The log activity trace level. Defaults to `null`.
+  `log_activity_trace_level` - (Optional) The log activity trace level. Specifies the activity-level tracing options of the runbook, available only for Graphical runbooks. Possible values are `0` for None, `9` for Basic, and `15` for Detailed. Must turn on Verbose logging in order to see the tracing.
   `publish_content_link` - (Optional) The publish content link block.
     `uri` - (Required) The URI of the content.
     `version` - (Optional) The version of the content.
@@ -623,10 +672,6 @@ Description: A list of Automation Runbooks which should be created in this Autom
       `mandatory` - (Optional) Whether the parameter is mandatory. Defaults to `null`.
       `position` - (Optional) The position of the parameter.
       `type` - (Required) The type of the parameter.
-  `job_schedule` - (Optional) The job schedule block.
-    `parameters` - (Required) A mapping of parameters.
-    `run_on` - (Required) The run on value.
-    `schedule_name` - (Required) The name of the schedule.
   `timeouts` - (Optional) The timeouts block.
 
 Example Input:
@@ -672,11 +717,6 @@ automation_runbooks = {
           type          = "string"
         }
       ]
-    }
-    job_schedule = {
-      parameters    = {"param1"="value1"}
-      run_on        = "Azure"
-      schedule_name = "myschedule"
     }
     timeouts = {
       create = "30m"
@@ -727,11 +767,6 @@ map(object({
         type          = string
       })))
     }))
-    job_schedule = optional(object({
-      parameters    = optional(map(string))
-      run_on        = optional(string)
-      schedule_name = string
-    }))
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -752,12 +787,12 @@ Description: A list of Automation Schedules which should be created in this Auto
   `interval` - (Optional) The number of `frequencys` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
   `start_time` - (Optional) The start time of the Schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created.
   `expiry_time` - (Optional) The expiry time of the Schedule.
-  `timezone` - (Optional) The timezone of the Schedule. Defaults to `UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
+  `timezone` - (Optional) The timezone of the Schedule. Defaults to `Etc/UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
   `week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
   `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
   `monthly_occurrence` - (Optional) One monthly\_occurrence blocks as defined below to specifies occurrences of days within a month. Only valid when frequency is `Month`.
-    `day` - (Required) The day of the month.
-    `occurrence` - (Required) The occurrence of the day in the month.
+    `day` - (Required) The day of the month. Must be one of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`
+    `occurrence` - (Required) The occurrence of the day in the month. Must be between `1` and `5`. `-1` for last week within the month.
   `timeouts` - (Optional) The timeouts block.
 
 Example Input:
@@ -797,7 +832,7 @@ map(object({
     interval    = optional(number, 1)
     start_time  = optional(string)
     expiry_time = optional(string)
-    timezone    = optional(string, "UTC")
+    timezone    = optional(string, "Etc/UTC")
     week_days   = optional(set(string))
     month_days  = optional(set(number))
     monthly_occurrence = optional(object({

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@
 
 This project uses GitHub Issues to track bugs and feature requests. Please search the existing issues before filing new issues to avoid duplicates. For new issues, file your bug or feature request as a new issue.
 
-Issues can be created and searched through for existing [issues here](https://github.com/didayal-msft/terraform-azurerm-avm-res-automation-automationaccount/issues).
+Issues can be created and searched through for existing [issues here](https://github.com/Poven795909/terraform-azurerm-avm-res-automation-automationaccount/issues).
 
 Please provide as much information as possible when filing an issue. Include screenshots or correlation IDs if possible (please redact any sensitive information).
 

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -44,7 +44,6 @@ module "azurerm_automation_account" {
     auto_conn_key1 = {
       name        = "example-connection"
       description = "This is an example connection"
-      type        = "Azure"
       type        = "AzureServicePrincipal"
       values = {
         "ApplicationId" : "00000000-0000-0000-0000-000000000000",

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -34,38 +34,17 @@ data "azurerm_client_config" "example" {}
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  public_network_access_enabled = true
-  sku                           = "Basic"
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
       description = "This is an example connection"
+      type        = "Azure"
       type        = "AzureServicePrincipal"
       values = {
         "ApplicationId" : "00000000-0000-0000-0000-000000000000",
@@ -74,6 +53,18 @@ module "azurerm_automation_account" {
         "CertificateThumbprint" : "sample-certificate-thumbprint",
       }
     }
+  }
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
+    }
+  }
+  public_network_access_enabled = true
+  tags = {
+    environment = "development"
   }
 }
 ```

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -38,7 +38,6 @@ module "azurerm_automation_account" {
     auto_conn_key1 = {
       name        = "example-connection"
       description = "This is an example connection"
-      type        = "Azure"
       type        = "AzureServicePrincipal"
       values = {
         "ApplicationId" : "00000000-0000-0000-0000-000000000000",

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -28,38 +28,17 @@ data "azurerm_client_config" "example" {}
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  public_network_access_enabled = true
-  sku                           = "Basic"
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
       description = "This is an example connection"
+      type        = "Azure"
       type        = "AzureServicePrincipal"
       values = {
         "ApplicationId" : "00000000-0000-0000-0000-000000000000",
@@ -68,5 +47,17 @@ module "azurerm_automation_account" {
         "CertificateThumbprint" : "sample-certificate-thumbprint",
       }
     }
+  }
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
+    }
+  }
+  public_network_access_enabled = true
+  tags = {
+    environment = "development"
   }
 }

--- a/examples/hybrid_workers/README.md
+++ b/examples/hybrid_workers/README.md
@@ -88,14 +88,13 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_windows_virtual_machine" "this" {
-  admin_password                    = random_password.password.result
-  admin_username                    = "testadmin"
-  location                          = azurerm_resource_group.this.location
-  name                              = "example-vm"
-  network_interface_ids             = [azurerm_network_interface.this.id]
-  resource_group_name               = azurerm_resource_group.this.name
-  size                              = "Standard_B1s"
-  vm_agent_platform_updates_enabled = true
+  admin_password        = random_password.password.result
+  admin_username        = "testadmin"
+  location              = azurerm_resource_group.this.location
+  name                  = "example-vm"
+  network_interface_ids = [azurerm_network_interface.this.id]
+  resource_group_name   = azurerm_resource_group.this.name
+  size                  = "Standard_B1s"
 
   os_disk {
     caching              = "ReadWrite"
@@ -114,16 +113,12 @@ resource "azurerm_windows_virtual_machine" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = true
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_credentials = {
     cred_1_key = {
       name        = "admin-password-credential"
@@ -138,21 +133,22 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_hybrid_runbook_worker_groups = {
     hybrid_worker_group_1_key = {
       name = "hybrid_worker_group_1"
       #credential_name = "admin-password-credential"
     }
   }
-
   automation_hybrid_runbook_workers = {
     hybrid_worker_1_key = {
       hybrid_worker_group_key = "hybrid_worker_group_1_key"
       vm_resource_id          = azurerm_windows_virtual_machine.this.id
     }
   }
-
+  public_network_access_enabled = true
+  tags = {
+    environment = "development"
+  }
 }
 
 resource "azurerm_virtual_machine_extension" "hybrid_worker_extension" {

--- a/examples/hybrid_workers/main.tf
+++ b/examples/hybrid_workers/main.tf
@@ -70,14 +70,13 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_windows_virtual_machine" "this" {
-  admin_password                    = random_password.password.result
-  admin_username                    = "testadmin"
-  location                          = azurerm_resource_group.this.location
-  name                              = "example-vm"
-  network_interface_ids             = [azurerm_network_interface.this.id]
-  resource_group_name               = azurerm_resource_group.this.name
-  size                              = "Standard_B1s"
-  vm_agent_platform_updates_enabled = true
+  admin_password        = random_password.password.result
+  admin_username        = "testadmin"
+  location              = azurerm_resource_group.this.location
+  name                  = "example-vm"
+  network_interface_ids = [azurerm_network_interface.this.id]
+  resource_group_name   = azurerm_resource_group.this.name
+  size                  = "Standard_B1s"
 
   os_disk {
     caching              = "ReadWrite"
@@ -96,16 +95,12 @@ resource "azurerm_windows_virtual_machine" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = true
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_credentials = {
     cred_1_key = {
       name        = "admin-password-credential"
@@ -120,21 +115,22 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_hybrid_runbook_worker_groups = {
     hybrid_worker_group_1_key = {
       name = "hybrid_worker_group_1"
       #credential_name = "admin-password-credential"
     }
   }
-
   automation_hybrid_runbook_workers = {
     hybrid_worker_1_key = {
       hybrid_worker_group_key = "hybrid_worker_group_1_key"
       vm_resource_id          = azurerm_windows_virtual_machine.this.id
     }
   }
-
+  public_network_access_enabled = true
+  tags = {
+    environment = "development"
+  }
 }
 
 resource "azurerm_virtual_machine_extension" "hybrid_worker_extension" {

--- a/examples/interfaces/README.md
+++ b/examples/interfaces/README.md
@@ -74,43 +74,12 @@ resource "azurerm_user_assigned_identity" "uami" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = true
-  # lock = {
-  #   kind = "CanNotDelete"
+  source = "../../"
 
-  # }
-  tags = {
-    environment = "development"
-  }
-  managed_identities = {
-    system_assigned = true
-    user_assigned_resource_ids = [
-      azurerm_user_assigned_identity.uami.id
-    ]
-  }
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
@@ -124,21 +93,12 @@ module "azurerm_automation_account" {
       }
     }
   }
-  role_assignments = {
-    self_contributor = {
-      role_definition_id_or_name       = "Contributor"
-      principal_id                     = data.azurerm_client_config.example.object_id
-      skip_service_principal_aad_check = true
-      principal_type                   = "ServicePrincipal"
-    },
-    role_assignment_2 = {
-      role_definition_id_or_name       = "Reader"
-      principal_id                     = data.azurerm_client_config.example.object_id # replace the principal id with appropriate one
-      description                      = "Example role assignment 2 of reader role"
-      skip_service_principal_aad_check = false
-      principal_type                   = "ServicePrincipal"
-      #condition                        = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
-      #condition_version                = "2.0"
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
     }
   }
   diagnostic_settings = {
@@ -159,8 +119,34 @@ module "azurerm_automation_account" {
       event_hub_name                           = azurerm_eventhub_namespace.eventhub_namespace.name
     }
   }
-
-
+  managed_identities = {
+    system_assigned = true
+    user_assigned_resource_ids = [
+      azurerm_user_assigned_identity.uami.id
+    ]
+  }
+  public_network_access_enabled = true
+  role_assignments = {
+    self_contributor = {
+      role_definition_id_or_name       = "Contributor"
+      principal_id                     = data.azurerm_client_config.example.object_id
+      skip_service_principal_aad_check = true
+      principal_type                   = "ServicePrincipal"
+    },
+    role_assignment_2 = {
+      role_definition_id_or_name       = "Reader"
+      principal_id                     = data.azurerm_client_config.example.object_id # replace the principal id with appropriate one
+      description                      = "Example role assignment 2 of reader role"
+      skip_service_principal_aad_check = false
+      principal_type                   = "ServicePrincipal"
+      #condition                        = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+      #condition_version                = "2.0"
+    }
+  }
+  # }
+  tags = {
+    environment = "development"
+  }
 }
 ```
 

--- a/examples/interfaces/main.tf
+++ b/examples/interfaces/main.tf
@@ -68,43 +68,12 @@ resource "azurerm_user_assigned_identity" "uami" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = true
-  # lock = {
-  #   kind = "CanNotDelete"
+  source = "../../"
 
-  # }
-  tags = {
-    environment = "development"
-  }
-  managed_identities = {
-    system_assigned = true
-    user_assigned_resource_ids = [
-      azurerm_user_assigned_identity.uami.id
-    ]
-  }
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
@@ -118,21 +87,12 @@ module "azurerm_automation_account" {
       }
     }
   }
-  role_assignments = {
-    self_contributor = {
-      role_definition_id_or_name       = "Contributor"
-      principal_id                     = data.azurerm_client_config.example.object_id
-      skip_service_principal_aad_check = true
-      principal_type                   = "ServicePrincipal"
-    },
-    role_assignment_2 = {
-      role_definition_id_or_name       = "Reader"
-      principal_id                     = data.azurerm_client_config.example.object_id # replace the principal id with appropriate one
-      description                      = "Example role assignment 2 of reader role"
-      skip_service_principal_aad_check = false
-      principal_type                   = "ServicePrincipal"
-      #condition                        = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
-      #condition_version                = "2.0"
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
     }
   }
   diagnostic_settings = {
@@ -153,6 +113,32 @@ module "azurerm_automation_account" {
       event_hub_name                           = azurerm_eventhub_namespace.eventhub_namespace.name
     }
   }
-
-
+  managed_identities = {
+    system_assigned = true
+    user_assigned_resource_ids = [
+      azurerm_user_assigned_identity.uami.id
+    ]
+  }
+  public_network_access_enabled = true
+  role_assignments = {
+    self_contributor = {
+      role_definition_id_or_name       = "Contributor"
+      principal_id                     = data.azurerm_client_config.example.object_id
+      skip_service_principal_aad_check = true
+      principal_type                   = "ServicePrincipal"
+    },
+    role_assignment_2 = {
+      role_definition_id_or_name       = "Reader"
+      principal_id                     = data.azurerm_client_config.example.object_id # replace the principal id with appropriate one
+      description                      = "Example role assignment 2 of reader role"
+      skip_service_principal_aad_check = false
+      principal_type                   = "ServicePrincipal"
+      #condition                        = "@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+      #condition_version                = "2.0"
+    }
+  }
+  # }
+  tags = {
+    environment = "development"
+  }
 }

--- a/examples/private_endpoints/README.md
+++ b/examples/private_endpoints/README.md
@@ -87,14 +87,13 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_windows_virtual_machine" "this" {
-  admin_password                    = random_password.password.result
-  admin_username                    = "testadmin"
-  location                          = azurerm_resource_group.this.location
-  name                              = "example-vm"
-  network_interface_ids             = [azurerm_network_interface.this.id]
-  resource_group_name               = azurerm_resource_group.this.name
-  size                              = "Standard_B1s"
-  vm_agent_platform_updates_enabled = true
+  admin_password        = random_password.password.result
+  admin_username        = "testadmin"
+  location              = azurerm_resource_group.this.location
+  name                  = "example-vm"
+  network_interface_ids = [azurerm_network_interface.this.id]
+  resource_group_name   = azurerm_resource_group.this.name
+  size                  = "Standard_B1s"
 
   os_disk {
     caching              = "ReadWrite"
@@ -125,16 +124,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = false
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_credentials = {
     cred_1_key = {
       name        = "admin-password-credential"
@@ -149,23 +144,18 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_hybrid_runbook_worker_groups = {
     hybrid_worker_group_1_key = {
       name = "hybrid_worker_group_1"
       # credential_name = "admin-password-credential"
     }
   }
-
   automation_hybrid_runbook_workers = {
     hybrid_worker_1_key = {
       hybrid_worker_group_key = "hybrid_worker_group_1_key"
       vm_resource_id          = azurerm_windows_virtual_machine.this.id
     }
   }
-
-
-  private_endpoints_manage_dns_zone_group = true
   private_endpoints = {
     pe-webhook = {
       # role_assignments   = {} # see interfaces/role assignments
@@ -186,6 +176,11 @@ module "azurerm_automation_account" {
       private_dns_zone_group_name   = "privatelink.azure-automation.net"
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
     }
+  }
+  private_endpoints_manage_dns_zone_group = true
+  public_network_access_enabled           = false
+  tags = {
+    environment = "development"
   }
 }
 resource "azurerm_virtual_machine_extension" "hybrid_worker_extension" {

--- a/examples/private_endpoints/main.tf
+++ b/examples/private_endpoints/main.tf
@@ -69,14 +69,13 @@ resource "random_password" "password" {
 }
 
 resource "azurerm_windows_virtual_machine" "this" {
-  admin_password                    = random_password.password.result
-  admin_username                    = "testadmin"
-  location                          = azurerm_resource_group.this.location
-  name                              = "example-vm"
-  network_interface_ids             = [azurerm_network_interface.this.id]
-  resource_group_name               = azurerm_resource_group.this.name
-  size                              = "Standard_B1s"
-  vm_agent_platform_updates_enabled = true
+  admin_password        = random_password.password.result
+  admin_username        = "testadmin"
+  location              = azurerm_resource_group.this.location
+  name                  = "example-vm"
+  network_interface_ids = [azurerm_network_interface.this.id]
+  resource_group_name   = azurerm_resource_group.this.name
+  size                  = "Standard_B1s"
 
   os_disk {
     caching              = "ReadWrite"
@@ -107,16 +106,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "example" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = false
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_credentials = {
     cred_1_key = {
       name        = "admin-password-credential"
@@ -131,23 +126,18 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_hybrid_runbook_worker_groups = {
     hybrid_worker_group_1_key = {
       name = "hybrid_worker_group_1"
       # credential_name = "admin-password-credential"
     }
   }
-
   automation_hybrid_runbook_workers = {
     hybrid_worker_1_key = {
       hybrid_worker_group_key = "hybrid_worker_group_1_key"
       vm_resource_id          = azurerm_windows_virtual_machine.this.id
     }
   }
-
-
-  private_endpoints_manage_dns_zone_group = true
   private_endpoints = {
     pe-webhook = {
       # role_assignments   = {} # see interfaces/role assignments
@@ -168,6 +158,11 @@ module "azurerm_automation_account" {
       private_dns_zone_group_name   = "privatelink.azure-automation.net"
       private_dns_zone_resource_ids = [azurerm_private_dns_zone.this.id]
     }
+  }
+  private_endpoints_manage_dns_zone_group = true
+  public_network_access_enabled           = false
+  tags = {
+    environment = "development"
   }
 }
 resource "azurerm_virtual_machine_extension" "hybrid_worker_extension" {

--- a/examples/shared_resources/README.md
+++ b/examples/shared_resources/README.md
@@ -46,35 +46,12 @@ data "azurerm_client_config" "example" {}
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = false
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # uncheck below block to use your certificate
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
@@ -88,29 +65,14 @@ module "azurerm_automation_account" {
       }
     }
   }
-
-  # The below block doesnt seem to have a use case. Keeping it till further clarity from terraform
-  # automation_connection_certificates = {
-  #   auto_conn_cert_key1 = {
-  #     connection_key = "auto_conn_key1"
-  #     automation_certificate_name = "example-certificate"
-  #     subscription_id = data.azurerm_client_config.example.subscription_id
-  #   }
-  # }
-
-  automation_schedules = {
-    auto_schedule_key1 = {
-      name        = "tfex-automation-schedule"
-      description = "This is an example schedule"
-      frequency   = "Week"
-      interval    = 1
-      #expiry_time = timeadd(timestamp, duration)
-      timezone   = "Etc/UTC"
-      start_time = "2027-04-15T18:00:15+02:00"
-      week_days  = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
     }
   }
-
   automation_modules = {
     auto_module_key1 = {
       name = "xActiveDirectory"
@@ -127,7 +89,6 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_python3_packages = {
     auto_python3_key1 = {
       name            = "example2"
@@ -140,7 +101,18 @@ module "azurerm_automation_account" {
       }
     }
   }
-
+  automation_schedules = {
+    auto_schedule_key1 = {
+      name        = "tfex-automation-schedule"
+      description = "This is an example schedule"
+      frequency   = "Week"
+      interval    = 1
+      #expiry_time = timeadd(timestamp, duration)
+      timezone   = "Etc/UTC"
+      start_time = "2027-04-15T18:00:15+02:00"
+      week_days  = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+    }
+  }
   automation_variable_bools = {
     auto_var_bool_key1 = {
       name        = "example-bool-variable"
@@ -153,7 +125,6 @@ module "azurerm_automation_account" {
       value       = false
     }
   }
-
   automation_variable_datetimes = {
     auto_var_dt_key1 = {
       name        = "example-datetime-variable"
@@ -161,7 +132,6 @@ module "azurerm_automation_account" {
       value       = "2035-08-01T00:00:00Z"
     }
   }
-
   automation_variable_ints = {
     auto_var_int_key1 = {
       name        = "example-int-variable"
@@ -174,7 +144,6 @@ module "azurerm_automation_account" {
       value       = 36
     }
   }
-
   automation_variable_objects = {
     auto_var_obj_key1 = {
       name        = "example-object-variable"
@@ -185,13 +154,16 @@ module "azurerm_automation_account" {
       })
     }
   }
-
   automation_variable_strings = {
     auto_var_string_key1 = {
       name        = "example-string-variable"
       description = "This is an example string variable"
       value       = "example-value"
     }
+  }
+  public_network_access_enabled = false
+  tags = {
+    environment = "development"
   }
 }
 ```

--- a/examples/shared_resources/main.tf
+++ b/examples/shared_resources/main.tf
@@ -28,35 +28,12 @@ data "azurerm_client_config" "example" {}
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
-  location                      = azurerm_resource_group.this.location
-  resource_group_name           = azurerm_resource_group.this.name
-  sku                           = "Basic"
-  public_network_access_enabled = false
-  tags = {
-    environment = "development"
-  }
+  source = "../../"
 
-  automation_credentials = {
-    auto_cred_key1 = {
-      name        = "example-credential"
-      description = "This is an example credential"
-      username    = "admin"
-      password    = "example_pwd"
-    }
-  }
-
-  # uncheck below block to use your certificate
-  # automation_certificates = {
-  #   auto_cert_key1 = {
-  #     name        = "example-certificate"
-  #     description = "This is an example certificate"
-  #     base64      = filebase64("certificate.pfx")
-  #     exportable  = true
-  #   }
-  # }
-
+  location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "Basic"
   automation_connections = {
     auto_conn_key1 = {
       name        = "example-connection"
@@ -70,29 +47,14 @@ module "azurerm_automation_account" {
       }
     }
   }
-
-  # The below block doesnt seem to have a use case. Keeping it till further clarity from terraform
-  # automation_connection_certificates = {
-  #   auto_conn_cert_key1 = {
-  #     connection_key = "auto_conn_key1"
-  #     automation_certificate_name = "example-certificate"
-  #     subscription_id = data.azurerm_client_config.example.subscription_id
-  #   }
-  # }
-
-  automation_schedules = {
-    auto_schedule_key1 = {
-      name        = "tfex-automation-schedule"
-      description = "This is an example schedule"
-      frequency   = "Week"
-      interval    = 1
-      #expiry_time = timeadd(timestamp, duration)
-      timezone   = "Etc/UTC"
-      start_time = "2027-04-15T18:00:15+02:00"
-      week_days  = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+  automation_credentials = {
+    auto_cred_key1 = {
+      name        = "example-credential"
+      description = "This is an example credential"
+      username    = "admin"
+      password    = "example_pwd"
     }
   }
-
   automation_modules = {
     auto_module_key1 = {
       name = "xActiveDirectory"
@@ -109,7 +71,6 @@ module "azurerm_automation_account" {
       }
     }
   }
-
   automation_python3_packages = {
     auto_python3_key1 = {
       name            = "example2"
@@ -122,7 +83,18 @@ module "azurerm_automation_account" {
       }
     }
   }
-
+  automation_schedules = {
+    auto_schedule_key1 = {
+      name        = "tfex-automation-schedule"
+      description = "This is an example schedule"
+      frequency   = "Week"
+      interval    = 1
+      #expiry_time = timeadd(timestamp, duration)
+      timezone   = "Etc/UTC"
+      start_time = "2027-04-15T18:00:15+02:00"
+      week_days  = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+    }
+  }
   automation_variable_bools = {
     auto_var_bool_key1 = {
       name        = "example-bool-variable"
@@ -135,7 +107,6 @@ module "azurerm_automation_account" {
       value       = false
     }
   }
-
   automation_variable_datetimes = {
     auto_var_dt_key1 = {
       name        = "example-datetime-variable"
@@ -143,7 +114,6 @@ module "azurerm_automation_account" {
       value       = "2035-08-01T00:00:00Z"
     }
   }
-
   automation_variable_ints = {
     auto_var_int_key1 = {
       name        = "example-int-variable"
@@ -156,7 +126,6 @@ module "azurerm_automation_account" {
       value       = 36
     }
   }
-
   automation_variable_objects = {
     auto_var_obj_key1 = {
       name        = "example-object-variable"
@@ -167,12 +136,15 @@ module "azurerm_automation_account" {
       })
     }
   }
-
   automation_variable_strings = {
     auto_var_string_key1 = {
       name        = "example-string-variable"
       description = "This is an example string variable"
       value       = "example-value"
     }
+  }
+  public_network_access_enabled = false
+  tags = {
+    environment = "development"
   }
 }

--- a/examples/source_control/README.md
+++ b/examples/source_control/README.md
@@ -44,32 +44,16 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
+  source = "../../"
+
   location                      = azurerm_resource_group.this.location
+  name                          = module.naming.automation_account.name_unique
   resource_group_name           = azurerm_resource_group.this.name
   sku                           = "Basic"
   public_network_access_enabled = false
   tags = {
     environment = "development"
   }
-
-  # The below block as been tested with an actual github repo and with a PAT. Currently this has been generalized. Please replace with appropriate values.
-  # automation_source_controls = {
-  #   auto_source-control_key1 = {
-  #     name                = "example-source-control"
-  #     description         = "This is an example source control"
-  #     source_control_type = "GitHub"
-  #     folder_path         = "/"
-  #     repository_url      = "https://github.com/ABCD/XYZ.git"
-  #     branch              = "dev"
-
-  #     security = {
-  #       token_type = "PersonalAccessToken"
-  #       token      = "ghp_xxxxxx"
-  #     }
-  #   }
-  # }
 }
 ```
 

--- a/examples/source_control/main.tf
+++ b/examples/source_control/main.tf
@@ -26,30 +26,14 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source                        = "../../"
-  name                          = module.naming.automation_account.name_unique
+  source = "../../"
+
   location                      = azurerm_resource_group.this.location
+  name                          = module.naming.automation_account.name_unique
   resource_group_name           = azurerm_resource_group.this.name
   sku                           = "Basic"
   public_network_access_enabled = false
   tags = {
     environment = "development"
   }
-
-  # The below block as been tested with an actual github repo and with a PAT. Currently this has been generalized. Please replace with appropriate values.
-  # automation_source_controls = {
-  #   auto_source-control_key1 = {
-  #     name                = "example-source-control"
-  #     description         = "This is an example source control"
-  #     source_control_type = "GitHub"
-  #     folder_path         = "/"
-  #     repository_url      = "https://github.com/ABCD/XYZ.git"
-  #     branch              = "dev"
-
-  #     security = {
-  #       token_type = "PersonalAccessToken"
-  #       token      = "ghp_xxxxxx"
-  #     }
-  #   }
-  # }
 }

--- a/examples/webhook/README.md
+++ b/examples/webhook/README.md
@@ -44,15 +44,31 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source              = "../../"
-  name                = module.naming.automation_account.name_unique
+  source = "../../"
+
   location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Basic"
-  tags = {
-    environment = "development"
+  # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
+  automation_job_schedules = {
+    auto_job_schedule_key1 = {
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key1"
+      parameters = {
+        resourcegroup = "myResourceGroup"
+        location      = "centralindia"
+      }
+    }
+    auto_job_schedule_key2 = {
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key2"
+      parameters = {
+        resourcegroup = "myResourceGroup"
+        vmname        = "TF-VM-01"
+      }
+    }
   }
-  public_network_access_enabled = false
   automation_runbooks = {
     auto_runbook_key1 = {
       name         = "Get-AzureVMTutorial"
@@ -60,13 +76,39 @@ module "azurerm_automation_account" {
       script_path  = "runbook.ps1"
       log_verbose  = "true"
       log_progress = "true"
-      runbook_type = "PowerShellWorkflow"
+      runbook_type = "PowerShell72"
       publish_content_link = {
         uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
       }
     }
   }
+  automation_schedules = {
+    auto_schedule_key1 = {
+      name        = "TestRunbook_schedule"
+      description = "This is an example schedule"
+      start_time  = "2025-06-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Month"
+      interval    = 1
+      time_zone   = "Etc/UTC"
+      month_days  = [1, 15]
+      monthly_occurrences = {
+        day        = "Friday"
+        occurrence = 1
+      }
+    }
 
+    auto_schedule_key2 = {
+      name        = "TestRunbook_schedule2"
+      description = "This is an example2 schedule"
+      start_time  = "2025-07-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Week"
+      interval    = 1
+      time_zone   = "Asia/Tokyo"
+      week_days   = ["Monday", "Wednesday", "Friday"]
+    }
+  }
   automation_webhooks = {
     auto_webhook_key1 = {
       name         = "TestRunbook_webhook"
@@ -77,6 +119,10 @@ module "azurerm_automation_account" {
         input = "parameter"
       }
     }
+  }
+  public_network_access_enabled = false
+  tags = {
+    environment = "development"
   }
 }
 ```

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -10,6 +10,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  subscription_id = "9ff79d1b-9fac-40a9-b1e6-f7791d2b9ba6"
 }
 
 # This ensures we have unique CAF compliant names for our resources.
@@ -45,6 +46,50 @@ module "azurerm_automation_account" {
       runbook_type = "PowerShellWorkflow"
       publish_content_link = {
         uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
+      }
+    }
+  }
+
+  automation_schedules = {
+    auto_schedule_key1 = {
+      name        = "TestRunbook_schedule"
+      description = "This is an example schedule"
+      start_time  = "2025-06-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Week"
+      interval    = 1
+      time_zone   = "Etc/UTC"
+      week_days   = ["Monday", "Wednesday", "Friday"]
+    }
+
+    auto_schedule_key2 = {
+      name        = "TestRunbook_schedule2"
+      description = "This is an example2 schedule"
+      start_time  = "2025-07-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Week"
+      interval    = 1
+      time_zone   = "Asia/Tokyo"
+      week_days   = ["Friday"]
+    }
+  }
+
+# Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
+  automation_job_schedules = {
+    auto_job_schedule_key1 = {
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key1"
+      parameters = {
+        resourcegroup = "myResourceGroup"
+        location      = "centralindia"
+      }
+    }
+    auto_job_schedule_key2 = {
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key2"
+      parameters = {
+        resourcegroup = "myResourceGroup"
+        vmname        = "TF-VM-01"
       }
     }
   }

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -26,53 +26,12 @@ resource "azurerm_resource_group" "this" {
 
 # This is the module call
 module "azurerm_automation_account" {
-  source              = "../../"
-  name                = module.naming.automation_account.name_unique
+  source = "../../"
+
   location            = azurerm_resource_group.this.location
+  name                = module.naming.automation_account.name_unique
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Basic"
-  tags = {
-    environment = "development"
-  }
-  public_network_access_enabled = false
-  automation_runbooks = {
-    auto_runbook_key1 = {
-      name         = "Get-AzureVMTutorial"
-      description  = "This is an example runbook"
-      script_path  = "runbook.ps1"
-      log_verbose  = "true"
-      log_progress = "true"
-      runbook_type = "PowerShellWorkflow"
-      publish_content_link = {
-        uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
-      }
-    }
-  }
-
-  automation_schedules = {
-    auto_schedule_key1 = {
-      name        = "TestRunbook_schedule"
-      description = "This is an example schedule"
-      start_time  = "2025-06-01T00:00:00Z"
-      expiry_time = "2027-12-31T00:00:00Z"
-      frequency   = "Week"
-      interval    = 1
-      time_zone   = "Etc/UTC"
-      week_days   = ["Monday", "Wednesday", "Friday"]
-    }
-
-    auto_schedule_key2 = {
-      name        = "TestRunbook_schedule2"
-      description = "This is an example2 schedule"
-      start_time  = "2025-07-01T00:00:00Z"
-      expiry_time = "2027-12-31T00:00:00Z"
-      frequency   = "Week"
-      interval    = 1
-      time_zone   = "Asia/Tokyo"
-      week_days   = ["Friday"]
-    }
-  }
-
   # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
   automation_job_schedules = {
     auto_job_schedule_key1 = {
@@ -92,7 +51,46 @@ module "azurerm_automation_account" {
       }
     }
   }
+  automation_runbooks = {
+    auto_runbook_key1 = {
+      name         = "Get-AzureVMTutorial"
+      description  = "This is an example runbook"
+      script_path  = "runbook.ps1"
+      log_verbose  = "true"
+      log_progress = "true"
+      runbook_type = "PowerShell72"
+      publish_content_link = {
+        uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
+      }
+    }
+  }
+  automation_schedules = {
+    auto_schedule_key1 = {
+      name        = "TestRunbook_schedule"
+      description = "This is an example schedule"
+      start_time  = "2025-06-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Month"
+      interval    = 1
+      time_zone   = "Etc/UTC"
+      month_days  = [1, 15]
+      monthly_occurrences = {
+        day        = "Friday"
+        occurrence = 1
+      }
+    }
 
+    auto_schedule_key2 = {
+      name        = "TestRunbook_schedule2"
+      description = "This is an example2 schedule"
+      start_time  = "2025-07-01T00:00:00Z"
+      expiry_time = "2027-12-31T00:00:00Z"
+      frequency   = "Week"
+      interval    = 1
+      time_zone   = "Asia/Tokyo"
+      week_days   = ["Monday", "Wednesday", "Friday"]
+    }
+  }
   automation_webhooks = {
     auto_webhook_key1 = {
       name         = "TestRunbook_webhook"
@@ -103,5 +101,9 @@ module "azurerm_automation_account" {
         input = "parameter"
       }
     }
+  }
+  public_network_access_enabled = false
+  tags = {
+    environment = "development"
   }
 }

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -10,7 +10,6 @@ terraform {
 
 provider "azurerm" {
   features {}
-  subscription_id = "9ff79d1b-9fac-40a9-b1e6-f7791d2b9ba6"
 }
 
 # This ensures we have unique CAF compliant names for our resources.
@@ -74,7 +73,7 @@ module "azurerm_automation_account" {
     }
   }
 
-# Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
+  # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
   automation_job_schedules = {
     auto_job_schedule_key1 = {
       runbook_key  = "auto_runbook_key1"

--- a/main.automation_hybrid_workers.tf
+++ b/main.automation_hybrid_workers.tf
@@ -18,9 +18,7 @@ resource "azurerm_automation_hybrid_runbook_worker_group" "this" {
   }
 }
 
-resource "random_uuid" "this" {
-  for_each = var.automation_hybrid_runbook_workers != null ? var.automation_hybrid_runbook_workers : {}
-}
+resource "random_uuid" "this" {}
 
 resource "azurerm_automation_hybrid_runbook_worker" "this" {
   for_each = var.automation_hybrid_runbook_workers != null ? var.automation_hybrid_runbook_workers : {}
@@ -29,5 +27,5 @@ resource "azurerm_automation_hybrid_runbook_worker" "this" {
   resource_group_name     = azurerm_automation_account.this.resource_group_name
   vm_resource_id          = each.value.vm_resource_id
   worker_group_name       = azurerm_automation_hybrid_runbook_worker_group.this[each.value.hybrid_worker_group_key].name
-  worker_id               = random_uuid.this[each.key].result
+  worker_id               = random_uuid.this.result
 }

--- a/main.automation_hybrid_workers.tf
+++ b/main.automation_hybrid_workers.tf
@@ -18,7 +18,9 @@ resource "azurerm_automation_hybrid_runbook_worker_group" "this" {
   }
 }
 
-resource "random_uuid" "this" {}
+resource "random_uuid" "this" {
+  for_each = var.automation_hybrid_runbook_workers != null ? var.automation_hybrid_runbook_workers : {}
+}
 
 resource "azurerm_automation_hybrid_runbook_worker" "this" {
   for_each = var.automation_hybrid_runbook_workers != null ? var.automation_hybrid_runbook_workers : {}
@@ -27,5 +29,5 @@ resource "azurerm_automation_hybrid_runbook_worker" "this" {
   resource_group_name     = azurerm_automation_account.this.resource_group_name
   vm_resource_id          = each.value.vm_resource_id
   worker_group_name       = azurerm_automation_hybrid_runbook_worker_group.this[each.value.hybrid_worker_group_key].name
-  worker_id               = random_uuid.this.result
+  worker_id               = random_uuid.this[each.key].result
 }

--- a/main.automation_runbooks.tf
+++ b/main.automation_runbooks.tf
@@ -50,10 +50,6 @@ resource "azurerm_automation_runbook" "this" {
       }
     }
   }
-  # Need to understand how Job_schedule needs to be configured.
-  # dynamic "job_schedule" {
-  #   for_each = each.value.job_schedule == null ? [] : [each.value.job_schedule]
-
   #   content {
   #     parameters    = job_schedule.value.parameters
   #     run_on        = job_schedule.value.run_on

--- a/main.automation_runbooks.tf
+++ b/main.automation_runbooks.tf
@@ -51,15 +51,15 @@ resource "azurerm_automation_runbook" "this" {
     }
   }
   # Need to understand how Job_schedule needs to be configured.
-  dynamic "job_schedule" {
-    for_each = each.value.job_schedule == null ? [] : [each.value.job_schedule]
+  # dynamic "job_schedule" {
+  #   for_each = each.value.job_schedule == null ? [] : [each.value.job_schedule]
 
-    content {
-      parameters    = job_schedule.value.parameters
-      run_on        = job_schedule.value.run_on
-      schedule_name = job_schedule.value.schedule_name
-    }
-  }
+  #   content {
+  #     parameters    = job_schedule.value.parameters
+  #     run_on        = job_schedule.value.run_on
+  #     schedule_name = job_schedule.value.schedule_name
+  #   }
+  # }
   dynamic "publish_content_link" {
     for_each = each.value.publish_content_link == null ? [] : [each.value.publish_content_link]
 

--- a/main.automation_schedules.tf
+++ b/main.automation_schedules.tf
@@ -35,8 +35,8 @@ resource "azurerm_automation_schedule" "this" {
 resource "azurerm_automation_job_schedule" "this" {
   for_each = var.automation_job_schedules != null ? var.automation_job_schedules : {}
 
-  resource_group_name     = azurerm_automation_account.this.resource_group_name
   automation_account_name = azurerm_automation_account.this.name
+  resource_group_name     = azurerm_automation_account.this.resource_group_name
   runbook_name            = azurerm_automation_runbook.this[each.value.runbook_key].name
   schedule_name           = azurerm_automation_schedule.this[each.value.schedule_key].name
   parameters              = each.value.parameters != null ? each.value.parameters : null

--- a/main.automation_schedules.tf
+++ b/main.automation_schedules.tf
@@ -35,11 +35,11 @@ resource "azurerm_automation_schedule" "this" {
 resource "azurerm_automation_job_schedule" "this" {
   for_each = var.automation_job_schedules != null ? var.automation_job_schedules : {}
 
-  resource_group_name = azurerm_automation_account.this.resource_group_name
+  resource_group_name     = azurerm_automation_account.this.resource_group_name
   automation_account_name = azurerm_automation_account.this.name
-  runbook_name = azurerm_automation_runbook.this[each.value.runbook_key].name
-  schedule_name = azurerm_automation_schedule.this[each.value.schedule_key].name
-  parameters = each.value.parameters != null ? each.value.parameters : null
+  runbook_name            = azurerm_automation_runbook.this[each.value.runbook_key].name
+  schedule_name           = azurerm_automation_schedule.this[each.value.schedule_key].name
+  parameters              = each.value.parameters != null ? each.value.parameters : null
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]

--- a/main.automation_schedules.tf
+++ b/main.automation_schedules.tf
@@ -28,8 +28,26 @@ resource "azurerm_automation_schedule" "this" {
       create = timeouts.value.create
       delete = timeouts.value.delete
       read   = timeouts.value.read
-      update = timeouts.value.update
     }
   }
 }
 
+resource "azurerm_automation_job_schedule" "this" {
+  for_each = var.automation_job_schedules != null ? var.automation_job_schedules : {}
+
+  resource_group_name = azurerm_automation_account.this.resource_group_name
+  automation_account_name = azurerm_automation_account.this.name
+  runbook_name = azurerm_automation_runbook.this[each.value.runbook_key].name
+  schedule_name = azurerm_automation_schedule.this[each.value.schedule_key].name
+  parameters = each.value.parameters != null ? each.value.parameters : null
+
+  dynamic "timeouts" {
+    for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
+
+    content {
+      create = timeouts.value.create
+      delete = timeouts.value.delete
+      read   = timeouts.value.read
+    }
+  }
+}

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -15,11 +15,11 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = {
+  tags = merge({
     subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
     tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
-  }
+  }, { location = var.location })
 }

--- a/main.telemetry.tf
+++ b/main.telemetry.tf
@@ -15,11 +15,11 @@ resource "random_uuid" "telemetry" {
 resource "modtm_telemetry" "telemetry" {
   count = var.enable_telemetry ? 1 : 0
 
-  tags = merge({
+  tags = {
     subscription_id = one(data.azurerm_client_config.telemetry).subscription_id
     tenant_id       = one(data.azurerm_client_config.telemetry).tenant_id
     module_source   = one(data.modtm_module_source.telemetry).module_source
     module_version  = one(data.modtm_module_source.telemetry).module_version
     random_id       = one(random_uuid.telemetry).result
-  }, { location = var.location })
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -518,7 +518,7 @@ variable "automation_runbooks" {
         type          = string
       })))
     }))
-  # Commenting out as creating a separate variable for automation_job_schedule
+    # Commenting out as creating a separate variable for automation_job_schedule
     # job_schedule = optional(object({
     #   parameters    = optional(map(string))
     #   run_on        = optional(string)
@@ -628,15 +628,15 @@ variable "automation_runbooks" {
   }
   ```
   EOT
-    nullable    = false
+  nullable    = false
 }
 
 variable "automation_job_schedules" {
   type = map(object({
-    runbook_key   = string
-    schedule_key  = string
-    parameters     = optional(map(string)) # must be in lowercase
-    run_on         = optional(string)
+    runbook_key  = string
+    schedule_key = string
+    parameters   = optional(map(string)) # must be in lowercase
+    run_on       = optional(string)
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)

--- a/variables.tf
+++ b/variables.tf
@@ -518,11 +518,12 @@ variable "automation_runbooks" {
         type          = string
       })))
     }))
-    job_schedule = optional(object({
-      parameters    = optional(map(string))
-      run_on        = optional(string)
-      schedule_name = string
-    }))
+  # Commenting out as creating a separate variable for automation_job_schedule
+    # job_schedule = optional(object({
+    #   parameters    = optional(map(string))
+    #   run_on        = optional(string)
+    #   schedule_name = string
+    # }))
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -626,7 +627,52 @@ variable "automation_runbooks" {
     }
   }
   ```
-EOT
+  EOT
+    nullable    = false
+}
+
+variable "automation_job_schedules" {
+  type = map(object({
+    runbook_key   = string
+    schedule_key  = string
+    parameters     = optional(map(string)) # must be in lowercase
+    run_on         = optional(string)
+    timeouts = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      read   = optional(string)
+    }))
+  }))
+  default     = {}
+  description = <<-EOT
+  A map of Automation Job Schedules to be created in this Automation Account.
+    `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
+    `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
+    `parameters` - (Optional) A map of parameters to pass to the Runbook.
+    `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
+    `timeouts` - (Optional) The timeouts block.
+
+  Example Input:
+  ```terraform
+  automation_job_schedule = {
+    "myjobschedule" = {
+      name          = "myjobschedule"
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key1"
+      parameters    = {
+        param1 = "value1"
+        param2 = "value2"
+      }
+      run_on = "Azure"
+      timeouts = {
+        create = "30m"
+        delete = "30m"
+        read   = "5m"
+      }
+    }
+  }
+  ```
+  EOT
   nullable    = false
 }
 
@@ -638,7 +684,7 @@ variable "automation_schedules" {
     interval    = optional(number, 1)
     start_time  = optional(string)
     expiry_time = optional(string)
-    timezone    = optional(string, "UTC")
+    timezone    = optional(string, "Etc/UTC")
     week_days   = optional(set(string))
     month_days  = optional(set(number))
     monthly_occurrence = optional(object({
@@ -661,7 +707,7 @@ variable "automation_schedules" {
     `interval` - (Optional) The number of `frequencys` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
     `start_time` - (Optional) The start time of the Schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created.
     `expiry_time` - (Optional) The expiry time of the Schedule.
-    `timezone` - (Optional) The timezone of the Schedule. Defaults to `UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
+    `timezone` - (Optional) The timezone of the Schedule. Defaults to `Etc/UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
     `week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
     `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
     `monthly_occurrence` - (Optional) One monthly_occurrence blocks as defined below to specifies occurrences of days within a month. Only valid when frequency is `Month`.

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,11 @@ variable "sku" {
   type        = string
   description = "The SKU of the Automation Account. Possible values are Basic and Free"
   nullable    = false
+
+  validation {
+    condition     = contains(["Basic", "Free"], var.sku)
+    error_message = "The SKU must be either 'Basic' or 'Free'."
+  }
 }
 
 variable "automation_certificates" {
@@ -62,7 +67,7 @@ variable "automation_certificates" {
     }
   }
   ```
-EOT
+  EOT
   nullable    = false
 }
 
@@ -174,7 +179,7 @@ variable "automation_connections" {
   description = <<-EOT
   A list of Automation Connections which should be created in this Automation Account.
     `name` - (Required) The name of the Connection.
-    `type` - (Required) The type of the Connection.
+    `type` - (Required) The type of the Connection. Can be either builtin type such as `Azure`, `AzureClassicCertificate`, and `AzureServicePrincipal`, or a user defined types. Changing this forces a new resource to be created.
     `values` - (Required) A mapping of key value pairs passed to the connection. Different `type` needs different parameters in the `values`. Builtin types have required field values as below:
       `Azure`: parameters `AutomationCertificateName` and `SubscriptionID`.
       `AzureServicePrincipal`: parameters `TenantID`, `ApplicationID`, and `CertificateThumbprint`.
@@ -202,8 +207,22 @@ variable "automation_connections" {
     }
   }
   ```
-EOT
+  EOT
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for k, v in var.automation_connections :
+      v.type == "Azure" ? (
+        contains(keys(v.values), "AutomationCertificateName") && contains(keys(v.values), "SubscriptionID")
+        ) : v.type == "AzureServicePrincipal" ? (
+        contains(keys(v.values), "TenantId") && contains(keys(v.values), "ApplicationId") && contains(keys(v.values), "CertificateThumbprint") && contains(keys(v.values), "SubscriptionId")
+        ) : v.type == "AzureClassicCertificate" ? (
+        contains(keys(v.values), "SubscriptionId") && contains(keys(v.values), "SubscriptionName") && contains(keys(v.values), "CertificateAssetName")
+      ) : true
+    ])
+    error_message = "For built-in types, 'values' must include required keys: Azure: AutomationCertificateName, SubscriptionID; AzureServicePrincipal: TenantID, ApplicationID, CertificateThumbprint; AzureClassicCertificate: SubscriptionID, SubscriptionName, CertificateAsserName."
+  }
 }
 
 variable "automation_credentials" {
@@ -282,7 +301,7 @@ variable "automation_hybrid_runbook_worker_groups" {
     }
   }
   ```
-EOT
+  EOT
   nullable    = false
 }
 
@@ -319,7 +338,52 @@ variable "automation_hybrid_runbook_workers" {
     }
   }
   ```
-EOT
+  EOT
+  nullable    = false
+}
+
+variable "automation_job_schedules" {
+  type = map(object({
+    runbook_key  = string
+    schedule_key = string
+    parameters   = optional(map(string)) # must be in lowercase
+    run_on       = optional(string)
+    timeouts = optional(object({
+      create = optional(string)
+      delete = optional(string)
+      read   = optional(string)
+    }))
+  }))
+  default     = {}
+  description = <<-EOT
+  A map of Automation Job Schedules to be created in this Automation Account.
+    `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
+    `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
+    `parameters` - (Optional) A map of parameters to pass to the Runbook.
+    `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
+    `timeouts` - (Optional) The timeouts block.
+
+  Example Input:
+  ```terraform
+  automation_job_schedule = {
+    "myjobschedule" = {
+      name          = "myjobschedule"
+      runbook_key  = "auto_runbook_key1"
+      schedule_key = "auto_schedule_key1"
+      parameters    = {
+        param1 = "value1"
+        param2 = "value2"
+      }
+      run_on = "Azure"
+      timeouts = {
+        create = "30m"
+        delete = "30m"
+        read   = "5m"
+      }
+    }
+  }
+  ```
+  EOT
   nullable    = false
 }
 
@@ -451,7 +515,7 @@ variable "automation_python3_packages" {
     `content_uri` - (Required) The URI of the content. Changing this forces a new Automation Python3 Package to be created.
     `content_version` - (Optional) The version of the content.  The value should meet the system.version class format like `1.1.1`. Changing this forces a new Automation Python3 Package to be created.
     `hash_algorithm` - (Optional) Specify the hash algorithm used to hash the content of the python3 package. Changing this forces a new Automation Python3 Package to be created.
-    `hash_value` - (Optional) Specity the hash value of the content. Changing this forces a new Automation Python3 Package to be created.
+    `hash_value` - (Optional) Specify the hash value of the content. Changing this forces a new Automation Python3 Package to be created.
     `tags` - (Optional) A mapping of tags to assign to the Module.
     `timeouts` - (Optional) The timeouts block.
 
@@ -479,6 +543,14 @@ variable "automation_python3_packages" {
   ```
   EOT
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_python3_packages :
+      v.content_version == null || can(regex("^\\d+\\.\\d+\\.\\d+$", v.content_version))
+    ])
+    error_message = "If specified, content_version must be in the format 'X.Y.Z', e.g., '1.1.1'."
+  }
 }
 
 variable "automation_runbooks" {
@@ -518,12 +590,6 @@ variable "automation_runbooks" {
         type          = string
       })))
     }))
-    # Commenting out as creating a separate variable for automation_job_schedule
-    # job_schedule = optional(object({
-    #   parameters    = optional(map(string))
-    #   run_on        = optional(string)
-    #   schedule_name = string
-    # }))
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -535,13 +601,13 @@ variable "automation_runbooks" {
   description = <<-EOT
   A list of Automation Runbooks which should be created in this Automation Account.
     `name` - (Required) The name of the Runbook.
-    `runbook_type` - (Required) The type of the Runbook. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `GraphPython2`, `GraphPython3`, `GraphPowerShellCore`, `GraphPowerShellCoreWorkflow`, `GraphPowerShellCorePython2`, `GraphPowerShellCorePython3`, `GraphPowerShellCorePowerShell`, `GraphPowerShellCorePowerShellWorkflow`, `GraphPowerShellCorePowerShellPython2`, `GraphPowerShellCorePowerShellPython3`, `GraphPowerShellCorePowerShellCore`, `GraphPowerShellCorePowerShellCoreWorkflow`, `GraphPowerShellCorePowerShellCorePython2`, `GraphPowerShellCorePowerShellCorePython3`.
+    `runbook_type` - (Required) The type of the Runbook. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShell72`, `Python3`, `Python2` or `Script`.
     `log_process` - (Required) Whether to log process details. Defaults to `true`.
     `log_verbose` - (Required) Whether to log verbose details. Defaults to `true`.
     `description` - (Optional) A description for this Runbook.
     `content` - (Optional) The content of the Runbook. Required if `publish_content_link` is not specified.
     `tags` - (Optional) A mapping of tags to assign to the Runbook.
-    `log_activity_trace_level` - (Optional) The log activity trace level. Defaults to `null`.
+    `log_activity_trace_level` - (Optional) The log activity trace level. Specifies the activity-level tracing options of the runbook, available only for Graphical runbooks. Possible values are `0` for None, `9` for Basic, and `15` for Detailed. Must turn on Verbose logging in order to see the tracing.
     `publish_content_link` - (Optional) The publish content link block.
       `uri` - (Required) The URI of the content.
       `version` - (Optional) The version of the content.
@@ -563,10 +629,6 @@ variable "automation_runbooks" {
         `mandatory` - (Optional) Whether the parameter is mandatory. Defaults to `null`.
         `position` - (Optional) The position of the parameter.
         `type` - (Required) The type of the parameter.
-    `job_schedule` - (Optional) The job schedule block.
-      `parameters` - (Required) A mapping of parameters.
-      `run_on` - (Required) The run on value.
-      `schedule_name` - (Required) The name of the schedule.
     `timeouts` - (Optional) The timeouts block.
 
   Example Input:
@@ -613,11 +675,6 @@ variable "automation_runbooks" {
           }
         ]
       }
-      job_schedule = {
-        parameters    = {"param1"="value1"}
-        run_on        = "Azure"
-        schedule_name = "myschedule"
-      }
       timeouts = {
         create = "30m"
         delete = "30m"
@@ -629,51 +686,27 @@ variable "automation_runbooks" {
   ```
   EOT
   nullable    = false
-}
 
-variable "automation_job_schedules" {
-  type = map(object({
-    runbook_key  = string
-    schedule_key = string
-    parameters   = optional(map(string)) # must be in lowercase
-    run_on       = optional(string)
-    timeouts = optional(object({
-      create = optional(string)
-      delete = optional(string)
-      read   = optional(string)
-    }))
-  }))
-  default     = {}
-  description = <<-EOT
-  A map of Automation Job Schedules to be created in this Automation Account.
-    `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
-    `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
-    `parameters` - (Optional) A map of parameters to pass to the Runbook.
-    `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
-    `timeouts` - (Optional) The timeouts block.
-
-  Example Input:
-  ```terraform
-  automation_job_schedule = {
-    "myjobschedule" = {
-      name          = "myjobschedule"
-      runbook_key  = "auto_runbook_key1"
-      schedule_key = "auto_schedule_key1"
-      parameters    = {
-        param1 = "value1"
-        param2 = "value2"
-      }
-      run_on = "Azure"
-      timeouts = {
-        create = "30m"
-        delete = "30m"
-        read   = "5m"
-      }
-    }
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_runbooks :
+      contains(
+        [
+          "PowerShell", "PowerShellWorkflow", "Graph", "GraphPowerShell", "GraphPowerShellWorkflow",
+          "PowerShell72", "Python3", "Python2", "Script"
+        ],
+        v.runbook_type
+      )
+    ])
+    error_message = "The runbook type must be one of the supported types. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShell72`, `Python3`, `Python2` or `Script`."
   }
-  ```
-  EOT
-  nullable    = false
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_runbooks :
+      v.log_activity_trace_level == null || contains([0, 9, 15], v.log_activity_trace_level)
+    ])
+    error_message = "log_activity_trace_level must be one of 0 (None), 9 (Basic), or 15 (Detailed) if specified."
+  }
 }
 
 variable "automation_schedules" {
@@ -711,8 +744,8 @@ variable "automation_schedules" {
     `week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
     `month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
     `monthly_occurrence` - (Optional) One monthly_occurrence blocks as defined below to specifies occurrences of days within a month. Only valid when frequency is `Month`.
-      `day` - (Required) The day of the month.
-      `occurrence` - (Required) The occurrence of the day in the month.
+      `day` - (Required) The day of the month. Must be one of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`
+      `occurrence` - (Required) The occurrence of the day in the month. Must be between `1` and `5`. `-1` for last week within the month.
     `timeouts` - (Optional) The timeouts block.
 
   Example Input:
@@ -743,6 +776,57 @@ variable "automation_schedules" {
   ```
   EOT
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_schedules :
+      contains(["OneTime", "Hour", "Day", "Week", "Month"], v.frequency)
+    ])
+    error_message = "The frequency must be one of the supported values: OneTime, Hour, Day, Week, or Month."
+  }
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_schedules :
+      v.interval == null || (v.frequency != "OneTime" && v.interval > 0)
+    ])
+    error_message = "If specified, interval must be greater than 0 and only valid when frequency is Day, Hour, Week, or Month."
+  }
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_schedules :
+      v.week_days == null || (
+        v.frequency == "Week" && alltrue([
+          for day in v.week_days :
+          contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], day)
+        ])
+      )
+    ])
+    error_message = "If specified, week_days must be a list of valid days of the week and only valid when frequency is Week. Possible values are Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday."
+  }
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_schedules :
+      v.month_days == null || (
+        v.frequency == "Month" && alltrue([
+          for day in v.month_days :
+          (day >= 1 && day <= 31) || day == -1
+        ])
+      )
+    ])
+    error_message = "If specified, month_days must be a list of valid days of the month (1-31) or -1 for the last day of the month and only valid when frequency is Month."
+  }
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_schedules :
+      v.monthly_occurrence == null || (
+        v.frequency == "Month" && (
+          contains(["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"], v.monthly_occurrence.day) &&
+          (v.monthly_occurrence.occurrence >= 1 && v.monthly_occurrence.occurrence <= 5 || v.monthly_occurrence.occurrence == -1)
+        )
+      )
+    ])
+    error_message = "If specified, monthly_occurrence must have a valid day (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday) and occurrence (1-5 or -1 for last week) and only valid when frequency is Month."
+  }
 }
 
 variable "automation_source_controls" {
@@ -804,6 +888,14 @@ variable "automation_source_controls" {
   ```
   EOT
   nullable    = false
+
+  validation {
+    condition = alltrue([
+      for _, v in var.automation_source_controls :
+      contains(["GitHub", "VsoGit", "VsoTfvc"], v.source_control_type)
+    ])
+    error_message = "The source_control_type must be one of the supported values: GitHub, VsoGit, or VsoTfvc."
+  }
 }
 
 variable "automation_variable_bools" {
@@ -1075,7 +1167,7 @@ variable "automation_watchers" {
     }
   }
   ```
-EOT
+  EOT
   nullable    = false
 }
 
@@ -1200,7 +1292,7 @@ variable "encryption" {
   - `user_assigned_identity_id` - (Optional) The User Assigned Managed Identity ID to be used for accessing the Customer Managed Key for encryption.
 
   > Note: The `key_source` property is deprecated and will be removed in a future version. Please use `key_vault_key_id` instead.
-EOT
+  EOT
 }
 
 variable "local_authentication_enabled" {
@@ -1390,5 +1482,5 @@ variable "timeouts" {
   - `delete` - (Defaults to 30 minutes) Used when deleting the Automation Account.
   - `read` - (Defaults to 5 minutes) Used when retrieving the Automation Account.
   - `update` - (Defaults to 30 minutes) Used when updating the Automation Account.
-EOT
+  EOT
 }


### PR DESCRIPTION
## Description

- Created a separate variable block for Job_Schedule with type "map" to allow multiple job schedules per runbook.
- Added Validation checks for below variables: -
   - automation_connections
   - automation_runbooks
   - automation_schedules
- Latest governance check

Fixes #23 
Closes #23 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
