### PR TITLE
Inclusion and ability to create multiple Job-Schedules inlined to Azurerm_automation_runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Default: `{}`
 
 ### <a name="input_automation_job_schedules"></a> [automation\_job\_schedules](#input\_automation\_job\_schedules)
 
-Description: A map of Automation Job Schedules to be created in this Automation Account.
+Description: A map of Automation Job Schedules to be created in this Automation Account. You can also use the inlined 'job\_schedule' property under `automation_runbooks` to create job schedules. However you should choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
   `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
   `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
   `parameters` - (Optional) A map of parameters to pass to the Runbook.
@@ -672,6 +672,10 @@ Description: A list of Automation Runbooks which should be created in this Autom
       `mandatory` - (Optional) Whether the parameter is mandatory. Defaults to `null`.
       `position` - (Optional) The position of the parameter.
       `type` - (Required) The type of the parameter.
+  `job_schedule` - (Optional) A list of job\_schedule blocks as defined below. You can also use the standalone 'automation\_job\_schedule' variable to create job schedules. However you should choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
+    `parameters` - (Optional) A map of parameters to pass to the Runbook.
+    `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
+    `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`. This must match a key in `automation_schedules`.
   `timeouts` - (Optional) The timeouts block.
 
 Example Input:
@@ -718,6 +722,16 @@ automation_runbooks = {
         }
       ]
     }
+    job_schedule = [
+      {
+        parameters    = {
+          param1 = "value1"
+          param2 = "value2"
+        }
+        run_on        = "Azure"
+        schedule_key = "my_schedule_key1"
+      }
+    ]
     timeouts = {
       create = "30m"
       delete = "30m"
@@ -767,6 +781,11 @@ map(object({
         type          = string
       })))
     }))
+    job_schedule = optional(list(object({
+      parameters   = optional(map(string))
+      run_on       = optional(string)
+      schedule_key = string # Must match a key in `automation_schedules`.
+    })))
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -784,7 +803,7 @@ Description: A list of Automation Schedules which should be created in this Auto
   `name` - (Required) The name of the Schedule.
   `frequency` - (Required) The frequency of the Schedule. Possible values are `OneTime`, `Hour`, `Day`, `Week` or `Month`.
   `description` - (Optional) A description for this Schedule.
-  `interval` - (Optional) The number of `frequencys` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
+  `interval` - (Optional) The number of `frequency's` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
   `start_time` - (Optional) The start time of the Schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created.
   `expiry_time` - (Optional) The expiry time of the Schedule.
   `timezone` - (Optional) The timezone of the Schedule. Defaults to `Etc/UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
@@ -810,7 +829,7 @@ automation_schedules = {
     month_days  = [1, 15, -1]
     monthly_occurrence = {
       day       = "Monday"
-      occurence = 2
+      occurrence = 2
     }
     timeouts = {
       create = "30m"
@@ -836,8 +855,8 @@ map(object({
     week_days   = optional(set(string))
     month_days  = optional(set(number))
     monthly_occurrence = optional(object({
-      day       = string
-      occurence = number
+      day        = string
+      occurrence = number
     }))
     timeouts = optional(object({
       create = optional(string)
@@ -1211,7 +1230,7 @@ Description: A list of webhook to be created for an Automation runbook in this A
   `name` - (Required) Specifies the name of the Webhook. Changing this forces a new resource to be created.
   `expiry_time` - (Required) Timestamp when the webhook expires. Changing this forces a new resource to be created.
   `enabled` - (Optional) Controls if Webhook is enabled. Defaults to `true`.
-  `runbook_name` - (Required) Name of the Automation Runbook to execute by Webhook.
+  `runbook_key` - (Required) The reference key of the Automation Runbook to execute by Webhook.
   `run_on_worker_group` - (Optional) Name of the hybrid worker group the Webhook job will run on.
   `parameters` - (Optional) Map of input parameters passed to runbook.
   `uri` - (Optional) The URI of the webhook. Changing this forces a new resource to be created.
@@ -1224,7 +1243,7 @@ automation_webhooks = {
     name                = "mywebhook"
     expiry_time         = "2023-12-31T23:59:59Z"
     enabled             = true
-    runbook_name        = "myrunbook"
+    runbook_key         = "auto_runbook_key1"
     run_on_worker_group = "mygroup"
     parameters          = {"param1"="value1"}
     uri                 = "https://example.com/mywebhook"
@@ -1245,7 +1264,7 @@ map(object({
     name                = string
     expiry_time         = string
     enabled             = optional(bool, true)
-    runbook_name        = string
+    runbook_key         = string
     run_on_worker_group = optional(string)
     parameters          = optional(map(string))
     uri                 = optional(string, null)

--- a/examples/webhook/README.md
+++ b/examples/webhook/README.md
@@ -51,25 +51,25 @@ module "azurerm_automation_account" {
   name                = module.naming.automation_account.name_unique
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Basic"
-  # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
-  automation_job_schedules = {
-    auto_job_schedule_key1 = {
-      runbook_key  = "auto_runbook_key1"
-      schedule_key = "auto_schedule_key1"
-      parameters = {
-        resourcegroup = "myResourceGroup"
-        location      = "centralindia"
-      }
-    }
-    auto_job_schedule_key2 = {
-      runbook_key  = "auto_runbook_key1"
-      schedule_key = "auto_schedule_key2"
-      parameters = {
-        resourcegroup = "myResourceGroup"
-        vmname        = "TF-VM-01"
-      }
-    }
-  }
+  # Uncheck the following line of code to use the Stand-alone azurerm_automation_job_schedule module. In such case ensure that you uncheck/remove the code for the inlined 'job_schedule' [Line 63-78] because at this time you can choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
+  # automation_job_schedules = {
+  #   auto_job_schedule_key1 = {
+  #     runbook_key  = "auto_runbook_key1" # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
+  #     schedule_key = "auto_schedule_key1"
+  #     parameters = {
+  #       resourcegroup = "myResourceGroup"
+  #       location      = "centralindia"
+  #     }
+  #   }
+  #   auto_job_schedule_key2 = {
+  #     runbook_key  = "auto_runbook_key1"
+  #     schedule_key = "auto_schedule_key2"
+  #     parameters = {
+  #       resourcegroup = "myResourceGroup"
+  #       vmname        = "TF-VM-01"
+  #     }
+  #   }
+  # }
   automation_runbooks = {
     auto_runbook_key1 = {
       name         = "Get-AzureVMTutorial"
@@ -78,6 +78,22 @@ module "azurerm_automation_account" {
       log_verbose  = "true"
       log_progress = "true"
       runbook_type = "PowerShell72"
+      job_schedule = [
+        {
+          parameters = {
+            resourcegroup = "myResourceGroup"
+            location      = "centralindia"
+          }
+          schedule_key = "auto_schedule_key1"
+        },
+        {
+          parameters = {
+            resourcegroup = "myResourceGroup"
+            vmname        = "TF-VM-01"
+          }
+          schedule_key = "auto_schedule_key2"
+        }
+      ]
       publish_content_link = {
         uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
       }
@@ -87,7 +103,7 @@ module "azurerm_automation_account" {
     auto_schedule_key1 = {
       name        = "TestRunbook_schedule"
       description = "This is an example schedule"
-      start_time  = "2025-06-01T00:00:00Z"
+      start_time  = "2026-06-01T00:00:00Z"
       expiry_time = "2027-12-31T00:00:00Z"
       frequency   = "Month"
       interval    = 1
@@ -102,7 +118,7 @@ module "azurerm_automation_account" {
     auto_schedule_key2 = {
       name        = "TestRunbook_schedule2"
       description = "This is an example2 schedule"
-      start_time  = "2025-07-01T00:00:00Z"
+      start_time  = "2026-07-01T00:00:00Z"
       expiry_time = "2027-12-31T00:00:00Z"
       frequency   = "Week"
       interval    = 1
@@ -112,10 +128,10 @@ module "azurerm_automation_account" {
   }
   automation_webhooks = {
     auto_webhook_key1 = {
-      name         = "TestRunbook_webhook"
-      expiry_time  = "2027-12-31T00:00:00Z"
-      enabled      = true
-      runbook_name = "Get-AzureVMTutorial"
+      name        = "TestRunbook_webhook"
+      expiry_time = "2027-12-31T00:00:00Z"
+      enabled     = true
+      runbook_key = "auto_runbook_key1"
       parameters = {
         input = "parameter"
       }

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -33,7 +33,7 @@ module "azurerm_automation_account" {
   name                = module.naming.automation_account.name_unique
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Basic"
-# Uncheck the following line of code to use the Stand-alone azurerm_automation_job_schedule module. In such case ensure that you uncheck/remove the code for the inlined 'job_schedule' [Line 63-78] because at this time you can choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
+  # Uncheck the following line of code to use the Stand-alone azurerm_automation_job_schedule module. In such case ensure that you uncheck/remove the code for the inlined 'job_schedule' [Line 63-78] because at this time you can choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
   # automation_job_schedules = {
   #   auto_job_schedule_key1 = {
   #     runbook_key  = "auto_runbook_key1" # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
@@ -62,19 +62,19 @@ module "azurerm_automation_account" {
       runbook_type = "PowerShell72"
       job_schedule = [
         {
-        parameters    = {
-          resourcegroup = "myResourceGroup"
-          location      = "centralindia"
-        }
-        schedule_key  = "auto_schedule_key1"
-      },
+          parameters = {
+            resourcegroup = "myResourceGroup"
+            location      = "centralindia"
+          }
+          schedule_key = "auto_schedule_key1"
+        },
         {
-        parameters    = {
-          resourcegroup = "myResourceGroup"
-          vmname        = "TF-VM-01"
+          parameters = {
+            resourcegroup = "myResourceGroup"
+            vmname        = "TF-VM-01"
+          }
+          schedule_key = "auto_schedule_key2"
         }
-        schedule_key  = "auto_schedule_key2"
-      }
       ]
       publish_content_link = {
         uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
@@ -110,10 +110,10 @@ module "azurerm_automation_account" {
   }
   automation_webhooks = {
     auto_webhook_key1 = {
-      name         = "TestRunbook_webhook"
-      expiry_time  = "2027-12-31T00:00:00Z"
-      enabled      = true
-      runbook_key  = "auto_runbook_key1"
+      name        = "TestRunbook_webhook"
+      expiry_time = "2027-12-31T00:00:00Z"
+      enabled     = true
+      runbook_key = "auto_runbook_key1"
       parameters = {
         input = "parameter"
       }

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -33,25 +33,25 @@ module "azurerm_automation_account" {
   name                = module.naming.automation_account.name_unique
   resource_group_name = azurerm_resource_group.this.name
   sku                 = "Basic"
-  # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
-  automation_job_schedules = {
-    auto_job_schedule_key1 = {
-      runbook_key  = "auto_runbook_key1"
-      schedule_key = "auto_schedule_key1"
-      parameters = {
-        resourcegroup = "myResourceGroup"
-        location      = "centralindia"
-      }
-    }
-    auto_job_schedule_key2 = {
-      runbook_key  = "auto_runbook_key1"
-      schedule_key = "auto_schedule_key2"
-      parameters = {
-        resourcegroup = "myResourceGroup"
-        vmname        = "TF-VM-01"
-      }
-    }
-  }
+# Uncheck the following line of code to use the Stand-alone azurerm_automation_job_schedule module. In such case ensure that you uncheck/remove the code for the inlined 'job_schedule' [Line 63-78] because at this time you can choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
+  # automation_job_schedules = {
+  #   auto_job_schedule_key1 = {
+  #     runbook_key  = "auto_runbook_key1" # Each Job_schedule must be associated with unique Schedule but can be associated with same Runbook.
+  #     schedule_key = "auto_schedule_key1"
+  #     parameters = {
+  #       resourcegroup = "myResourceGroup"
+  #       location      = "centralindia"
+  #     }
+  #   }
+  #   auto_job_schedule_key2 = {
+  #     runbook_key  = "auto_runbook_key1"
+  #     schedule_key = "auto_schedule_key2"
+  #     parameters = {
+  #       resourcegroup = "myResourceGroup"
+  #       vmname        = "TF-VM-01"
+  #     }
+  #   }
+  # }
   automation_runbooks = {
     auto_runbook_key1 = {
       name         = "Get-AzureVMTutorial"
@@ -60,6 +60,22 @@ module "azurerm_automation_account" {
       log_verbose  = "true"
       log_progress = "true"
       runbook_type = "PowerShell72"
+      job_schedule = [
+        {
+        parameters    = {
+          resourcegroup = "myResourceGroup"
+          location      = "centralindia"
+        }
+        schedule_key  = "auto_schedule_key1"
+      },
+        {
+        parameters    = {
+          resourcegroup = "myResourceGroup"
+          vmname        = "TF-VM-01"
+        }
+        schedule_key  = "auto_schedule_key2"
+      }
+      ]
       publish_content_link = {
         uri = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/c4935ffb69246a6058eb24f54640f53f69d3ac9f/101-automation-runbook-getvms/Runbooks/Get-AzureVMTutorial.ps1"
       }
@@ -97,7 +113,7 @@ module "azurerm_automation_account" {
       name         = "TestRunbook_webhook"
       expiry_time  = "2027-12-31T00:00:00Z"
       enabled      = true
-      runbook_name = "Get-AzureVMTutorial"
+      runbook_key  = "auto_runbook_key1"
       parameters = {
         input = "parameter"
       }

--- a/examples/webhook/main.tf
+++ b/examples/webhook/main.tf
@@ -69,7 +69,7 @@ module "azurerm_automation_account" {
     auto_schedule_key1 = {
       name        = "TestRunbook_schedule"
       description = "This is an example schedule"
-      start_time  = "2025-06-01T00:00:00Z"
+      start_time  = "2026-06-01T00:00:00Z"
       expiry_time = "2027-12-31T00:00:00Z"
       frequency   = "Month"
       interval    = 1
@@ -84,7 +84,7 @@ module "azurerm_automation_account" {
     auto_schedule_key2 = {
       name        = "TestRunbook_schedule2"
       description = "This is an example2 schedule"
-      start_time  = "2025-07-01T00:00:00Z"
+      start_time  = "2026-07-01T00:00:00Z"
       expiry_time = "2027-12-31T00:00:00Z"
       frequency   = "Week"
       interval    = 1

--- a/main.automation_runbooks.tf
+++ b/main.automation_runbooks.tf
@@ -56,7 +56,7 @@ resource "azurerm_automation_runbook" "this" {
     content {
       parameters    = job_schedule.value.parameters
       run_on        = job_schedule.value.run_on
-      schedule_name = azurerm_automation_schedule.this[job_schedule.value.schedule_reference_key].name
+      schedule_name = azurerm_automation_schedule.this[job_schedule.value.schedule_key].name
     }
   }
   #   content {

--- a/main.automation_runbooks.tf
+++ b/main.automation_runbooks.tf
@@ -50,6 +50,15 @@ resource "azurerm_automation_runbook" "this" {
       }
     }
   }
+  dynamic "job_schedule" {
+    for_each = each.value.job_schedule == null ? [] : each.value.job_schedule
+
+    content {
+      parameters    = job_schedule.value.parameters
+      run_on        = job_schedule.value.run_on
+      schedule_name = azurerm_automation_schedule.this[job_schedule.value.schedule_reference_key].name
+    }
+  }
   #   content {
   #     parameters    = job_schedule.value.parameters
   #     run_on        = job_schedule.value.run_on

--- a/main.automation_webhooks.tf
+++ b/main.automation_webhooks.tf
@@ -5,7 +5,7 @@ resource "azurerm_automation_webhook" "this" {
   expiry_time             = each.value.expiry_time
   name                    = each.value.name
   resource_group_name     = azurerm_automation_account.this.resource_group_name
-  runbook_name            = each.value.runbook_name
+  runbook_name            = azurerm_automation_runbook.this[each.value.runbook_key].name
   enabled                 = each.value.enabled
   parameters              = each.value.parameters
   run_on_worker_group     = each.value.run_on_worker_group

--- a/variables.tf
+++ b/variables.tf
@@ -356,7 +356,7 @@ variable "automation_job_schedules" {
   }))
   default     = {}
   description = <<-EOT
-  A map of Automation Job Schedules to be created in this Automation Account. You can also use the inlined 'job_schedule' property under `automation_runbooks` to create job schedules. However you should choose only one of them to manage job schedule resources.
+  A map of Automation Job Schedules to be created in this Automation Account. You can also use the inlined 'job_schedule' property under `automation_runbooks` to create job schedules. However you should choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
     `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
     `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
     `parameters` - (Optional) A map of parameters to pass to the Runbook.
@@ -593,7 +593,7 @@ variable "automation_runbooks" {
     job_schedule = optional(list(object({
       parameters    = optional(map(string))
       run_on        = optional(string)
-      schedule_reference_key = string # Must match a key in `automation_schedules`.
+      schedule_key  = string # Must match a key in `automation_schedules`.
     })))
     timeouts = optional(object({
       create = optional(string)
@@ -634,10 +634,10 @@ variable "automation_runbooks" {
         `mandatory` - (Optional) Whether the parameter is mandatory. Defaults to `null`.
         `position` - (Optional) The position of the parameter.
         `type` - (Required) The type of the parameter.
-    `job_schedule` - (Optional) A list of job_schedule blocks as defined below. You can also use the standalone 'automation_job_schedule' variable to create job schedules. However you should choose only one of them to manage job schedule resources.
+    `job_schedule` - (Optional) A list of job_schedule blocks as defined below. You can also use the standalone 'automation_job_schedule' variable to create job schedules. However you should choose only one of them to manage job schedule resources. Refer https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/automation_job_schedule
       `parameters` - (Optional) A map of parameters to pass to the Runbook.
       `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
-      `schedule_reference_key` - (Required) The key of the Schedule defined in `automation_schedules`. This must match a key in `automation_schedules`.
+      `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`. This must match a key in `automation_schedules`.
     `timeouts` - (Optional) The timeouts block.
 
   Example Input:
@@ -691,7 +691,7 @@ variable "automation_runbooks" {
             param2 = "value2"
           }
           run_on        = "Azure"
-          schedule_reference_key = "my_schedule_key1"
+          schedule_key = "my_schedule_key1"
         }
       ]
       timeouts = {

--- a/variables.tf
+++ b/variables.tf
@@ -722,7 +722,7 @@ variable "automation_schedules" {
     month_days  = optional(set(number))
     monthly_occurrence = optional(object({
       day       = string
-      occurence = number
+      occurrence = number
     }))
     timeouts = optional(object({
       create = optional(string)
@@ -737,7 +737,7 @@ variable "automation_schedules" {
     `name` - (Required) The name of the Schedule.
     `frequency` - (Required) The frequency of the Schedule. Possible values are `OneTime`, `Hour`, `Day`, `Week` or `Month`.
     `description` - (Optional) A description for this Schedule.
-    `interval` - (Optional) The number of `frequencys` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
+    `interval` - (Optional) The number of `frequency's` between runs. Only valid when frequency is `Day`, `Hour`, `Week`, or `Month` and defaults to `1`.
     `start_time` - (Optional) The start time of the Schedule. Must be at least five minutes in the future. Defaults to seven minutes in the future from the time the resource is created.
     `expiry_time` - (Optional) The expiry time of the Schedule.
     `timezone` - (Optional) The timezone of the Schedule. Defaults to `Etc/UTC`.For possible values see: https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows.
@@ -763,7 +763,7 @@ variable "automation_schedules" {
       month_days  = [1, 15, -1]
       monthly_occurrence = {
         day       = "Monday"
-        occurence = 2
+        occurrence = 2
       }
       timeouts = {
         create = "30m"

--- a/variables.tf
+++ b/variables.tf
@@ -591,9 +591,9 @@ variable "automation_runbooks" {
       })))
     }))
     job_schedule = optional(list(object({
-      parameters    = optional(map(string))
-      run_on        = optional(string)
-      schedule_key  = string # Must match a key in `automation_schedules`.
+      parameters   = optional(map(string))
+      run_on       = optional(string)
+      schedule_key = string # Must match a key in `automation_schedules`.
     })))
     timeouts = optional(object({
       create = optional(string)
@@ -740,7 +740,7 @@ variable "automation_schedules" {
     week_days   = optional(set(string))
     month_days  = optional(set(number))
     monthly_occurrence = optional(object({
-      day       = string
+      day        = string
       occurrence = number
     }))
     timeouts = optional(object({
@@ -1195,7 +1195,7 @@ variable "automation_webhooks" {
     name                = string
     expiry_time         = string
     enabled             = optional(bool, true)
-    runbook_key        = string
+    runbook_key         = string
     run_on_worker_group = optional(string)
     parameters          = optional(map(string))
     uri                 = optional(string, null)

--- a/variables.tf
+++ b/variables.tf
@@ -356,7 +356,7 @@ variable "automation_job_schedules" {
   }))
   default     = {}
   description = <<-EOT
-  A map of Automation Job Schedules to be created in this Automation Account.
+  A map of Automation Job Schedules to be created in this Automation Account. You can also use the inlined 'job_schedule' property under `automation_runbooks` to create job schedules. However you should choose only one of them to manage job schedule resources.
     `runbook_key` - (Required) The key of the Runbook defined in `automation_runbooks`.
     `schedule_key` - (Required) The key of the Schedule defined in `automation_schedules`.
     `parameters` - (Optional) A map of parameters to pass to the Runbook.
@@ -590,6 +590,11 @@ variable "automation_runbooks" {
         type          = string
       })))
     }))
+    job_schedule = optional(list(object({
+      parameters    = optional(map(string))
+      run_on        = optional(string)
+      schedule_reference_key = string # Must match a key in `automation_schedules`.
+    })))
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -629,6 +634,10 @@ variable "automation_runbooks" {
         `mandatory` - (Optional) Whether the parameter is mandatory. Defaults to `null`.
         `position` - (Optional) The position of the parameter.
         `type` - (Required) The type of the parameter.
+    `job_schedule` - (Optional) A list of job_schedule blocks as defined below. You can also use the standalone 'automation_job_schedule' variable to create job schedules. However you should choose only one of them to manage job schedule resources.
+      `parameters` - (Optional) A map of parameters to pass to the Runbook.
+      `run_on` - (Optional) The name of the Hybrid Worker Group the job will run on.
+      `schedule_reference_key` - (Required) The key of the Schedule defined in `automation_schedules`. This must match a key in `automation_schedules`.
     `timeouts` - (Optional) The timeouts block.
 
   Example Input:
@@ -675,6 +684,16 @@ variable "automation_runbooks" {
           }
         ]
       }
+      job_schedule = [
+        {
+          parameters    = {
+            param1 = "value1"
+            param2 = "value2"
+          }
+          run_on        = "Azure"
+          schedule_reference_key = "my_schedule_key1"
+        }
+      ]
       timeouts = {
         create = "30m"
         delete = "30m"
@@ -1176,7 +1195,7 @@ variable "automation_webhooks" {
     name                = string
     expiry_time         = string
     enabled             = optional(bool, true)
-    runbook_name        = string
+    runbook_key        = string
     run_on_worker_group = optional(string)
     parameters          = optional(map(string))
     uri                 = optional(string, null)
@@ -1193,7 +1212,7 @@ variable "automation_webhooks" {
     `name` - (Required) Specifies the name of the Webhook. Changing this forces a new resource to be created.
     `expiry_time` - (Required) Timestamp when the webhook expires. Changing this forces a new resource to be created.
     `enabled` - (Optional) Controls if Webhook is enabled. Defaults to `true`.
-    `runbook_name` - (Required) Name of the Automation Runbook to execute by Webhook.
+    `runbook_key` - (Required) The reference key of the Automation Runbook to execute by Webhook.
     `run_on_worker_group` - (Optional) Name of the hybrid worker group the Webhook job will run on.
     `parameters` - (Optional) Map of input parameters passed to runbook.
     `uri` - (Optional) The URI of the webhook. Changing this forces a new resource to be created.
@@ -1206,7 +1225,7 @@ variable "automation_webhooks" {
       name                = "mywebhook"
       expiry_time         = "2023-12-31T23:59:59Z"
       enabled             = true
-      runbook_name        = "myrunbook"
+      runbook_key         = "auto_runbook_key1"
       run_on_worker_group = "mygroup"
       parameters          = {"param1"="value1"}
       uri                 = "https://example.com/mywebhook"


### PR DESCRIPTION
## Description

- Corrected few typos identified in the code (occurrence with a spelling mistake under Automation schedules)
- Added ability to create and link multiple job_schedules to a runbook as part of inlined property in Azurerm_automation_runbook
- Corrected a bug identified under azurem_automation_webhook where it was referencing the runbook name instead of type.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [x] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
