### PR TITLE
runbook inputs fixes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -557,8 +557,8 @@ variable "automation_runbooks" {
   type = map(object({
     name                     = string
     runbook_type             = string
-    log_progress             = bool
-    log_verbose              = bool
+    log_progress             = optional(bool, true)
+    log_verbose              = optional(bool, true)
     description              = optional(string, "test")
     content                  = optional(string, null)
     tags                     = optional(map(string))
@@ -607,7 +607,7 @@ variable "automation_runbooks" {
   A list of Automation Runbooks which should be created in this Automation Account.
     `name` - (Required) The name of the Runbook.
     `runbook_type` - (Required) The type of the Runbook. Possible values are `PowerShell`, `PowerShellWorkflow`, `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShell72`, `Python3`, `Python2` or `Script`.
-    `log_process` - (Required) Whether to log process details. Defaults to `true`.
+    `log_progress` - (Required) Whether to log process details. Defaults to `true`.
     `log_verbose` - (Required) Whether to log verbose details. Defaults to `true`.
     `description` - (Optional) A description for this Runbook.
     `content` - (Optional) The content of the Runbook. Required if `publish_content_link` is not specified.


### PR DESCRIPTION
- made runbook inputs `log_progress` & `log_verbose` optional with `true` default value to match their current variable description.
- fixed a typo in variable description.

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
